### PR TITLE
docs(procesos): Añadir proceso de transición de rol - PR17

### DIFF
--- a/docs/Procesos/PR16.md
+++ b/docs/Procesos/PR16.md
@@ -1,0 +1,69 @@
+# PR16-Proceso de transición de rol
+
+## Objetivo
+Definir los pasos para formalizar la transición de un rol de liderazgo (AO, PO, TL, PM, entre otros) en el departamento.
+
+## Entradas
+- Acuerdo formal o informal sobre miembro de equipo a asumir el rol.
+
+## Procedimiento
+<table>
+    <thead>
+        <th>Fase</th>
+        <th>Descripción</th>
+        <th>Responsables</th>
+        <th>Áreas CMMI</th>
+    </thead>
+
+<tbody>
+    <tr>
+      <td>Comunicado Inicial</td>
+      <td>
+        Comunicar internamente en el equipo de trabajo el miembro del equipo que asumirá el nuevo rol. Si se trata de PM, se refiere al departamento; si se trata de AO, PO o TL, se refiere al equipo de liderazgo y al equipo de proyecto.
+      </td>
+      <td>Líder actual y miembro del equipo a asumir el rol</td>
+      <td>
+        --
+      </td>
+    </tr>
+    <tr>
+      <td>Inducción</td>
+      <td>
+        Familiarizar al nuevo líder con las responsabilidades del ocupante actual. Esto incluye invitar al nuevo líder a las juntas pertinentes durante la transición de rol. Para más información sobre las responsabilidades de cada rol, se pueden consultar las guías de rol correspondientes.
+      </td>
+      <td>Líder actual</td>
+      <td>
+        --
+      </td>
+    </tr>
+     <tr>
+      <td>Inducción II</td>
+      <td>
+        Familiarizar al nuevo líder con la organización y documentación de la que se encarga el ocupante actual. En caso de POs puede referirse a medios de contacto preferidos y horas establecidas con stakeholders, por ejemplo.
+      </td>
+      <td>Líder actual</td>
+      <td>
+        --
+      </td>
+    </tr>
+    <tr>
+      <td>Comunicado Final Externo</td>
+      <td>
+        Comunicar a los stakeholders pertinentes y miembros fuera del equipo de trabajo sobre el cambio de ocupante del rol. Se comunicará la fecha acordada en que el nuevo líder comenzará a operar como tal.
+      </td>
+      <td>Líder actual y miembro del equipo a asumir el rol</td>
+      <td>
+        --
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Salidas
+- Notificación sobre inicio de operaciones del nuevo líder.
+- Fecha de inicio de operaciones del nuevo líder.
+
+## Versiones
+| Versión | Descripción                | Responsables        | Fecha      |
+| ------- | -------------------------- | ------------------- | ---------- |
+| 1.0     | Creación del proceso       | Guillermo C. Espino | 03/04/2022 |

--- a/docs/Procesos/PR17.md
+++ b/docs/Procesos/PR17.md
@@ -1,4 +1,4 @@
-# PR16-Proceso de transición de rol
+# PR17-Proceso de transición de rol
 
 ## Objetivo
 Definir los pasos para formalizar la transición de un rol de liderazgo (AO, PO, TL, PM, entre otros) en el departamento.
@@ -19,7 +19,11 @@ Definir los pasos para formalizar la transición de un rol de liderazgo (AO, PO,
     <tr>
       <td>Comunicado Inicial</td>
       <td>
+        <ul>
+        <li>
         Comunicar internamente en el equipo de trabajo el miembro del equipo que asumirá el nuevo rol. Si se trata de PM, se refiere al departamento; si se trata de AO, PO o TL, se refiere al equipo de liderazgo y al equipo de proyecto.
+        </li>
+        </ul>
       </td>
       <td>Líder actual y miembro del equipo a asumir el rol</td>
       <td>
@@ -29,17 +33,13 @@ Definir los pasos para formalizar la transición de un rol de liderazgo (AO, PO,
     <tr>
       <td>Inducción</td>
       <td>
-        Familiarizar al nuevo líder con las responsabilidades del ocupante actual. Esto incluye invitar al nuevo líder a las juntas pertinentes durante la transición de rol. Para más información sobre las responsabilidades de cada rol, se pueden consultar las guías de rol correspondientes.
-      </td>
-      <td>Líder actual</td>
-      <td>
-        --
-      </td>
-    </tr>
-     <tr>
-      <td>Inducción II</td>
-      <td>
+        <ul>
+        <li>Familiarizar al nuevo líder con las responsabilidades del ocupante actual. Esto incluye invitar al nuevo líder a las juntas pertinentes durante la transición de rol. Para más información sobre las responsabilidades de cada rol, se pueden consultar las guías de rol correspondientes (<a href="https://mutateinc.github.io/docs/Guias/GU04">Guía del PM</a>, <a href="https://mutateinc.github.io/docs/Guias/GU03">Guía del AO</a>, <a href="https://mutateinc.github.io/docs/Guias/GU05">Guía del PO</a>, <a href="https://mutateinc.github.io/docs/Guias/GU06">Guía del TL</a>).
+        </li>
+        <li>
         Familiarizar al nuevo líder con la organización y documentación de la que se encarga el ocupante actual. En caso de POs puede referirse a medios de contacto preferidos y horas establecidas con stakeholders, por ejemplo.
+        </li>
+        </ul>
       </td>
       <td>Líder actual</td>
       <td>
@@ -49,7 +49,11 @@ Definir los pasos para formalizar la transición de un rol de liderazgo (AO, PO,
     <tr>
       <td>Comunicado Final Externo</td>
       <td>
+      <ul>
+      <li>
         Comunicar a los stakeholders pertinentes y miembros fuera del equipo de trabajo sobre el cambio de ocupante del rol. Se comunicará la fecha acordada en que el nuevo líder comenzará a operar como tal.
+      </li>
+      </ul>
       </td>
       <td>Líder actual y miembro del equipo a asumir el rol</td>
       <td>


### PR DESCRIPTION
Al notar con mi propia transición como PO la necesidad de establecer pasos para pasar la batuta, decidí proponer un **Proceso para la transición de roles**. Este proceso es sencillo y flexible, y permite asegurar que los nuevos líderes lleguen en blanco de la mano de los líderes anteriores.

Está actualmente nombrado como el 16 dado que vi que el 15 está por agregarse.